### PR TITLE
Using a spare when degraded requires sync

### DIFF
--- a/images/fsm.dot
+++ b/images/fsm.dot
@@ -34,7 +34,7 @@ digraph outline {
         "redundancy start" -> "degraded" [label="failure/removal"];
 
         "degraded" -> "degraded" [label="do nothing"];
-        "degraded" -> "redundancy start" [label="spare used"];
+        "degraded" -> "redundancy sync" [label="spare used"];
         "degraded" -> "redundancy sync" [label="storage added"];
         "degraded" -> "redundancy end" [label="unrecoverable"];
 


### PR DESCRIPTION
The spare disk needs to be initialized based upon the data in the other
disks in the raid.

Signed-off-by: Andy Grover <agrover@redhat.com>