### PR TITLE
Slight alteration

### DIFF
--- a/docs/design/StratisSoftwareDesign.lyx
+++ b/docs/design/StratisSoftwareDesign.lyx
@@ -1401,8 +1401,8 @@ Data Tier
 
 \begin_layout Standard
 The data tier achieves these requirements by layering device-mapper (DM)
- devices on top of the pool's blockdevs, culminating in a thin devices allocated
- from a thinpool.
+ devices on top of the pool's blockdevs.
+ The topmost layer consists of thin devices allocated from a thinpool.
  Stratis initializes these thin devices with a filesystem, and manages the
  DM devices and filesystems to meet the above requirements.
 \end_layout


### PR DESCRIPTION
"in a thin devices" was obviously wrong, and "culminate" is a tricky word
that _usually_ has something to do with a process rather than a static
structure. I think this is better.

Signed-off-by: mulhern <amulhern@redhat.com>