### PR TITLE
Update Design doc and D-Bus API for renamed blockdev properties

### DIFF
--- a/docs/dbus/DBusAPIReference.lyx
+++ b/docs/dbus/DBusAPIReference.lyx
@@ -105,7 +105,7 @@ Anne Mulhern
 \end_layout
 
 \begin_layout Date
-Version 0.2
+Version 0.2.1
 \begin_inset ERT
 status collapsed
 
@@ -120,7 +120,7 @@ status collapsed
 
 \end_inset
 
-Last modified: 09/07/2017
+Last modified: 10/10/2017
 \end_layout
 
 \begin_layout Standard
@@ -745,7 +745,7 @@ Devnode The device node of the blockdev.
 \end_layout
 
 \begin_layout Description
-HardwareId The hardware-derived ID for this blockdev.
+HardwareInfo The hardware-derived ID for this blockdev.
  May be empty.
  This property is constant.
  Signature: s.
@@ -839,7 +839,7 @@ Bad
 \end_layout
 
 \begin_layout Description
-UserId The user-defined ID for this blockdev.
+UserInfo The user-defined string associated with this blockdev.
  May be empty.
  Signature: s.
 \end_layout

--- a/docs/design/StratisSoftwareDesign.lyx
+++ b/docs/design/StratisSoftwareDesign.lyx
@@ -79,7 +79,7 @@
 \begin_body
 
 \begin_layout Title
-Stratis Software Design: Version 0.8.4
+Stratis Software Design: Version 0.8.5
 \begin_inset Foot
 status collapsed
 
@@ -109,7 +109,7 @@ status collapsed
 \end_layout
 
 \begin_layout Date
-Last modified: 08/21/2017
+Last modified: 10/10/2017
 \end_layout
 
 \begin_layout Standard
@@ -3831,7 +3831,7 @@ the blockdev's most recently recorded device node
 \begin_inset Text
 
 \begin_layout Plain Layout
-location
+user_info
 \end_layout
 
 \end_inset
@@ -3869,7 +3869,7 @@ user-provided information for tracking the device
 \begin_inset Text
 
 \begin_layout Plain Layout
-disk_id
+hardware_info
 \end_layout
 
 \end_inset


### PR DESCRIPTION
These two docs were inconsistent. We now call these two blockdev
fields "user_info" (or UserInfo) and "hardware_info"
(or HardwareInfo) in both.

Signed-off-by: Andy Grover <agrover@redhat.com>