### PR TITLE
design & FAQ: Replace /dev/stratis mentions with /stratis

### DIFF
--- a/docs/design/StratisSoftwareDesign.lyx
+++ b/docs/design/StratisSoftwareDesign.lyx
@@ -5740,14 +5740,14 @@ OS Integration: /dev entries
 \begin_layout Standard
 Stratis allows the user to create filesystems, which then can be mounted
  and used via mount(8) and the fstab(5).
- Stratisd creates a /dev/stratis directory.
- It creates /dev/stratis/<poolname> for each pool present on the system,
- and /dev/stratis/<poolname>/<filesystemname> for each filesystem within
- the pool.
+ Stratisd creates a /stratis directory.
+ It creates /stratis/<poolname> for each pool present on the system, and
+ /stratis/<poolname>/<filesystemname> for each filesystem within the pool.
  Changes such as creations, removals, and renames are reflected in the entries
- under /dev/stratis.
+ under /stratis.
  These entries give the user a well-known path to a device to use for mounting
  the Stratis filesystem.
+ Filesystems may also be listed in /etc/fstab using XFS UUID.
 \end_layout
 
 \begin_layout Subsection

--- a/docs/faq/FAQ.md
+++ b/docs/faq/FAQ.md
@@ -65,7 +65,7 @@ tested using LVM logical volumes as block devices for Stratis pools.
 
 Stratis pools and filesystems both are given names are part of the creation
 process. Stratis creates links to filesystems under
-`/dev/stratis/<pool-name>/<filesystem-name>`. These may be used in
+`/stratis/<pool-name>/<filesystem-name>`. These may be used in
 `/etc/fstab`, but if pools or filesystems are renamed in the future, be sure
 to update `/etc/fstab` accordingly. Alternatively you can use the `blkid` tool
 to get the XFS filesystem UUID, and use that, which remains constant across


### PR DESCRIPTION
This is the new location that stratisd uses to maintain symlinks.

fixes #110

Signed-off-by: Andy Grover <agrover@redhat.com>