### PR TITLE
Fix DBus API Reference documentation regarding AddDevs method

### DIFF
--- a/docs/dbus/DBusAPIReference.lyx
+++ b/docs/dbus/DBusAPIReference.lyx
@@ -427,12 +427,6 @@ redundancy the redundancy specification for the pool.
 \end_layout
 
 \begin_layout Description
-force if true, the method will claim all devices specified, regardless of
- whether they seem to belong to another application.
- Signature: b.
-\end_layout
-
-\begin_layout Description
 devices device nodes of devices to form the pool.
  Signature: as.
 \end_layout
@@ -490,7 +484,7 @@ Methods
 \end_layout
 
 \begin_layout Description
-AddDevs This method allows additional devices to be added to the pool after
+AddCacheDevs This method allows additional cache devices to be added to the pool after
  it is created.
 \end_layout
 
@@ -499,10 +493,25 @@ AddDevs This method allows additional devices to be added to the pool after
 Arguments:
 \end_layout
 
+\begin_layout Description
+devices this argument has the same meaning as the device argument of CreatePool.
+ Signature: as.
+\end_layout
+
+\end_deeper
+\begin_layout Description
+Returns: a list of object paths of the blockdevs added to the pool.
+ Signature: a(o)qs.
+\end_layout
+
+\begin_layout Description
+AddDataDevs This method allows additional data devices to be added to the pool after
+ it is created.
+\end_layout
+
 \begin_deeper
 \begin_layout Description
-force this option has the same meaning as the force option of CreatePool.
- Signature: b.
+Arguments:
 \end_layout
 
 \begin_layout Description


### PR DESCRIPTION
Section 4.2 of the DBus API Reference document indicates a method
'AddDevs' that seems to have been replaced by two new methods:
'AddCacheDevs' and 'AddDataDevs' (or rather, AddDevs became
'AddDataDevs', and a new method 'AddCacheDevs' was added).
This change was introduced via commit
3f55d8c34b1a0df50bfbfb00ded85ce4859b8ad5 but the docs didn't seem to
show it. This patch is an attempt to reflect the change.

Signed-off-by: Jose Castillo <jcastillo@redhat.com>