### PR TITLE
Update the Red Hat tutorial link

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -18,7 +18,7 @@ build_search_index = true
 hyde_sticky = false
 hyde_theme = "theme-base-10"
 hyde_user_links = [
-    {url = "https://lab.redhat.com/stratis", name = "Tutorial"},
+    {url = "https://lab.redhat.com/stratis-configure", name = "Tutorial"},
     {url = "$BASE_URL/howto", name = "How-To"},
 ]
 hyde_developer_links = [

--- a/content/katacoda-tutorial.md
+++ b/content/katacoda-tutorial.md
@@ -9,7 +9,7 @@ render = true
 *mulhern, Stratis Team*
 
 We would like to thank Red Hat for hosting a Katacoda tutorial for Stratis at
-[lab.redhat.com/stratis]. We hope that the tutorial will provide an easy and
+[lab.redhat.com/stratis-configure]. We hope that the tutorial will provide an easy and
 pleasant introduction to Stratis for new users.
 
 Please note that the tutorial does not include the latest work on encryption,
@@ -20,4 +20,4 @@ as it makes use of a prior version of Stratis, 2.0.0.
 We hope to post links to additional Katacoda tutorials covering more advanced
 or recent Stratis functionality as they become available.
 
-[lab.redhat.com/stratis]: https://lab.redhat.com/stratis
+[lab.redhat.com/stratis-configure]: https://lab.redhat.com/stratis-configure


### PR DESCRIPTION
The tutorial has seemingly moved from `/stratis` to `/stratis-configure`.