### PR TITLE
Specify .service in /etc/fstab examples

### DIFF
--- a/content/stratis-rootfs.md
+++ b/content/stratis-rootfs.md
@@ -69,7 +69,7 @@ We now also provide a systemd service to manage setting up non-root filesystems 
 /etc/fstab.  For devices that require a passphrase or are critical for a working
 system, the following line can be used:
 
-`/dev/stratis/[STRATIS_SYMLINK] [MOUNT_POINT] xfs defaults,x-systemd.requires=stratis-fstab-setup@[POOL_UUID],x-systemd.after=stratis-fstab-setup@[POOL_UUID] 0 2`
+`/dev/stratis/[STRATIS_SYMLINK] [MOUNT_POINT] xfs defaults,x-systemd.requires=stratis-fstab-setup@[POOL_UUID].service,x-systemd.after=stratis-fstab-setup@[POOL_UUID].service 0 2`
 
 The absence of `nofail` here is due to the fact that `nofail` causes the boot to
 proceed prior to a successful mount. This means that passphrase prompts
@@ -80,7 +80,7 @@ For devices that do not require interaction to set up, such as unencrypted devic
 devices that have Clevis bindings, and are not critical for a working system, the
 following line can be optionally used:
 
-`/dev/stratis/[STRATIS_SYMLINK] [MOUNT_POINT] xfs defaults,x-systemd.requires=stratis-fstab-setup@[POOL_UUID],x-systemd.after=stratis-fstab-setup@[POOL_UUID],nofail 0 2`
+`/dev/stratis/[STRATIS_SYMLINK] [MOUNT_POINT] xfs defaults,x-systemd.requires=stratis-fstab-setup@[POOL_UUID].service,x-systemd.after=stratis-fstab-setup@[POOL_UUID].service,nofail 0 2`
 
 The addition of `nofail` here will cause mounting of this device to proceed
 independently from the boot which can speed up boot times. The set up process will
@@ -119,4 +119,8 @@ filesystem will be included in stratisd 2.4.0.
 
 <!-- more -->
 
-[`serde_json`]: https://github.com/serde-rs/json
+### Corrections
+* The `/etc/fstab` examples previously omitted `.service` for `stratis-fstab-setup`. systemd
+assumes that any unit dependency in `/etc/fstab` is a `.mount` unit file unless explicitly
+specified, so the examples as previously written would cause a failed boot unless `nofail`
+was specified.


### PR DESCRIPTION
Without the `.service` suffix specified, systemd will assume that the specified unit file is a `.mount` file and will fail as written.

We should update the documentation to specify this for users looking to implement /etc/fstab support.