### PR TITLE
Add stratis-cli archlinux package

### DIFF
--- a/content/static/users.md
+++ b/content/static/users.md
@@ -11,7 +11,7 @@ you would like any others to be added to the list.
 
 # Supported Operating Systems
 
-* Arch Linux: <https://archlinux.org/packages/community/x86_64/stratisd/>
+* Arch Linux: <https://archlinux.org/packages/community/x86_64/stratisd/>, <https://archlinux.org/packages/community/any/stratis-cli/>
 * Fedora: <https://src.fedoraproject.org/rpms/stratisd/>, <https://src.fedoraproject.org/rpms/stratis-cli>
 
 # Clients


### PR DESCRIPTION
Added the stratis-cli package url to users/index.html to let users know that the stratis-cli is also available for archlinux.

(pulled across from stratis-storage/stratis-storage.github.io#31)