### PR TITLE
Remove x-systemd.after= component of example fstab entries

### DIFF
--- a/content/static/howto.md
+++ b/content/static/howto.md
@@ -145,7 +145,7 @@ If you insert the following line in your /etc/fstab file, your pool will be
 started and your filesystem will be mounted during the boot process.
 
 ```
-/dev/stratis/<pool name>/<file system name> /mnt xfs defaults,x-systemd.requires=stratis-fstab-setup@<pool uuid>.service,x-systemd.after=stratis-fstab-setup@<pool uuid>.service 0 2
+/dev/stratis/<pool name>/<file system name> /mnt xfs defaults,x-systemd.requires=stratis-fstab-setup@<pool uuid>.service 0 2
 ```
 
 This will ensure that the filesystem's pool is started. In case the pool

--- a/content/stratis-release-notes-3.8.1.md
+++ b/content/stratis-release-notes-3.8.1.md
@@ -33,7 +33,7 @@ a cyclic dependency, and the boot process will fail.
 An example fstab entry for a filesystem on a pool that is encrypted using
 NBDE should look something like this:
 
-`/dev/stratis/<POOL_NAME>/<FILESYSTEM_NAME> <MOUNTPOINT> xfs defaults,_netdev,x-systemd.requires=stratis-fstab-setup-with-network@<POOL_UUID>.service,x-systemd.after=stratis-fstab-setup-with-network@<POOL_UUID>.service 0 2`
+`/dev/stratis/<POOL_NAME>/<FILESYSTEM_NAME> <MOUNTPOINT> xfs defaults,_netdev,x-systemd.requires=stratis-fstab-setup-with-network@<POOL_UUID>.service 0 2`
 
 If a filesystem's pool does not require that the network is up to be
 unlocked then the fstab entry may use the existing

--- a/content/stratis-rootfs.md
+++ b/content/stratis-rootfs.md
@@ -71,7 +71,7 @@ We now also provide a systemd service to manage setting up non-root filesystems 
 /etc/fstab.  For devices that require a passphrase or are critical for a working
 system, the following line can be used:
 
-`/dev/stratis/[STRATIS_SYMLINK] [MOUNT_POINT] xfs defaults,x-systemd.requires=stratis-fstab-setup@[POOL_UUID].service,x-systemd.after=stratis-fstab-setup@[POOL_UUID].service 0 2`
+`/dev/stratis/[STRATIS_SYMLINK] [MOUNT_POINT] xfs defaults,x-systemd.requires=stratis-fstab-setup@[POOL_UUID].service 0 2`
 
 The absence of `nofail` here is due to the fact that `nofail` causes the boot to
 proceed prior to a successful mount. This means that passphrase prompts
@@ -82,7 +82,7 @@ For devices that do not require interaction to set up, such as unencrypted devic
 devices that have Clevis bindings, and are not critical for a working system, the
 following line can be optionally used:
 
-`/dev/stratis/[STRATIS_SYMLINK] [MOUNT_POINT] xfs defaults,x-systemd.requires=stratis-fstab-setup@[POOL_UUID].service,x-systemd.after=stratis-fstab-setup@[POOL_UUID].service,nofail 0 2`
+`/dev/stratis/[STRATIS_SYMLINK] [MOUNT_POINT] xfs defaults,x-systemd.requires=stratis-fstab-setup@[POOL_UUID].service,nofail 0 2`
 
 The addition of `nofail` here will cause mounting of this device to proceed
 independently from the boot which can speed up boot times. The set up process will

--- a/content/stratis-rootfs.md
+++ b/content/stratis-rootfs.md
@@ -124,6 +124,11 @@ filesystem will be included in stratisd 2.4.0.
 assumes that any unit dependency in `/etc/fstab` is a `.mount` unit file unless explicitly
 specified, so the examples as previously written would cause a failed boot unless `nofail`
 was specified.
+* `systemd-fstab-generator` automatically includes an After constraint as
+well as a Requires constraint in the generated mouunt file when it processes
+an `x-systemd.requires=` option in an fstab entry.  The
+`x-systemd.after=stratis-fstab-setup@<pool uuid>.service` option in the
+example fstab entry has been removed, since it is redundant.
 
 ### Fedora specific set up
 See [this guide] for specific setup steps on Fedora.


### PR DESCRIPTION
Closes #368 