### PR TITLE
Increase CURRENT DEVELOPMENT ENVIRONMENT to Fedora 42

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -21,7 +21,7 @@ jobs:
       - name: Install dependencies
         run: dnf install -y make lyx 'dnf-command(copr)'
       - name: Enable copr repo
-        run: dnf copr enable atim/zola --assumeyes
+        run: dnf copr enable pgdev/zola --assumeyes
       - name: Install zola
         run: dnf install zola --assumeyes
       - name: Run test


### PR DESCRIPTION
Related https://github.com/stratis-storage/project/issues/805

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated CI/CD infrastructure to use Fedora 42 for build and testing processes.
  * Updated documentation build tooling dependencies.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->